### PR TITLE
fix caffe reinitialization bug in mil stage after maskout stage

### DIFF
--- a/features/cache_fc7_features.m
+++ b/features/cache_fc7_features.m
@@ -47,9 +47,9 @@ fprintf('~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n');
 % load the region of interest database
 roidb = imdb.roidb_func(imdb);
 
-if caffe('is_initialized') == 0
-    caffe('init', opts.net_def_file, opts.net_file, 'test');
-end
+
+caffe('init', opts.net_def_file, opts.net_file, 'test');
+
 % caffe('set_mode_cpu');
 caffe('set_mode_gpu');
 % caffe('set_device',3);


### PR DESCRIPTION
There is a tiny but tricky bug in [cache_fc7_features.m](https://github.com/jbhuang0604/WSL/blob/master/features/cache_fc7_features.m), and could be fixed by this PR.

In [READMD.md](https://github.com/jbhuang0604/WSL/blob/master/README.md), we perform mil stage right after maskout stage. We cache fc8 feature in maskout stage, and cache fc7 feature in mil stage. Because matcaffe do NOT use object-oriented design, once we initialization a network via matcaffe, we actually use the **same** network in all `caffe('forward', data)` in matlab afterward. 

So, if we don't reinitialize caffe after maskout stage, we will still cache **fc8** feature in `cache_fc7_features.m` called by `mil.m`, which is unpleasurable. 

Initialize matcaffe for multiple times is proved to be feasible after my several tests in several computers, and is pretty fast (~50ms).
